### PR TITLE
chore(build): add gitleaks secret scanning workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,19 @@
+name: Gitleaks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}


### PR DESCRIPTION
## Summary
- Adds a Gitleaks GitHub Actions workflow to scan for secrets on pull requests and pushes to the default branch
- Uses `gitleaks/gitleaks-action@v2` with `GITLEAKS_LICENSE` secret

Reference: https://github.com/questdb/questdb/pull/6863